### PR TITLE
Docs sidebar: center + align brand row

### DIFF
--- a/installer/build_docs.py
+++ b/installer/build_docs.py
@@ -381,25 +381,38 @@ def render_html(tools: list[str], python_packages: list[str], urls: list[str], p
   aside.sidebar {{
     background: var(--sidebar-bg);
     border-right: 1px solid var(--border);
-    padding: 32px 0 32px 24px;
+    padding: 28px 20px;
     position: sticky;
     top: 0;
     align-self: start;
     height: 100vh;
     overflow-y: auto;
   }}
+  /* Brand row: logo + wordmark, centered as a unit on the sidebar with
+     a subtle separator below before the nav. The fixed-square image box
+     guarantees vertical-center alignment between logo and text even
+     though the underlying logo PNG has internal whitespace. */
   .sidebar-brand {{
     display: flex;
     align-items: center;
-    gap: 8px;
-    margin-bottom: 20px;
+    justify-content: center;
+    gap: 10px;
+    margin: 0 0 20px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--border);
     text-decoration: none;
     color: var(--text);
-    font-weight: 600;
+    font-weight: 700;
     font-size: 14px;
+    letter-spacing: 0.01em;
   }}
-  .sidebar-brand img {{ width: 22px; height: auto; }}
-  .sidebar-brand .label {{ letter-spacing: 0.02em; }}
+  .sidebar-brand img {{
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+    flex: 0 0 auto;
+  }}
+  .sidebar-brand .label {{ line-height: 1.2; }}
   .sidebar h3 {{
     font-size: 11px;
     text-transform: uppercase;
@@ -410,14 +423,13 @@ def render_html(tools: list[str], python_packages: list[str], urls: list[str], p
   }}
   .sidebar a {{
     display: block;
-    padding: 6px 12px 6px 0;
+    padding: 6px 12px 6px 10px;
     color: var(--text);
     text-decoration: none;
     font-size: 14px;
     line-height: 1.4;
     border-left: 2px solid transparent;
     margin-left: -2px;
-    padding-left: 10px;
   }}
   .sidebar a:hover {{ color: var(--gold); }}
   .sidebar a.active {{ border-left-color: var(--sidebar-active); font-weight: 600; }}

--- a/installer/docs/index.html
+++ b/installer/docs/index.html
@@ -37,25 +37,38 @@
   aside.sidebar {
     background: var(--sidebar-bg);
     border-right: 1px solid var(--border);
-    padding: 32px 0 32px 24px;
+    padding: 28px 20px;
     position: sticky;
     top: 0;
     align-self: start;
     height: 100vh;
     overflow-y: auto;
   }
+  /* Brand row: logo + wordmark, centered as a unit on the sidebar with
+     a subtle separator below before the nav. The fixed-square image box
+     guarantees vertical-center alignment between logo and text even
+     though the underlying logo PNG has internal whitespace. */
   .sidebar-brand {
     display: flex;
     align-items: center;
-    gap: 8px;
-    margin-bottom: 20px;
+    justify-content: center;
+    gap: 10px;
+    margin: 0 0 20px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--border);
     text-decoration: none;
     color: var(--text);
-    font-weight: 600;
+    font-weight: 700;
     font-size: 14px;
+    letter-spacing: 0.01em;
   }
-  .sidebar-brand img { width: 22px; height: auto; }
-  .sidebar-brand .label { letter-spacing: 0.02em; }
+  .sidebar-brand img {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+    flex: 0 0 auto;
+  }
+  .sidebar-brand .label { line-height: 1.2; }
   .sidebar h3 {
     font-size: 11px;
     text-transform: uppercase;
@@ -66,14 +79,13 @@
   }
   .sidebar a {
     display: block;
-    padding: 6px 12px 6px 0;
+    padding: 6px 12px 6px 10px;
     color: var(--text);
     text-decoration: none;
     font-size: 14px;
     line-height: 1.4;
     border-left: 2px solid transparent;
     margin-left: -2px;
-    padding-left: 10px;
   }
   .sidebar a:hover { color: var(--gold); }
   .sidebar a.active { border-left-color: var(--sidebar-active); font-weight: 600; }


### PR DESCRIPTION
Small CSS fix in build_docs.py — brand row in the docs sidebar was left-adrift and the logo wasn't vertically centered with the wordmark. Symmetric padding + fixed-square logo box + justify-content: center fixes both. Live at passporttowealth.app/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)