### PR TITLE
Landing brand: 'Clarity App' rename + mobile suffix hide

### DIFF
--- a/installer/index.html
+++ b/installer/index.html
@@ -107,6 +107,11 @@
       letter-spacing: 0.04em;
       flex: 1;
     }
+    /* Drop the "· CLARITY APP" suffix on mobile so the header stays readable
+       alongside the Docs link + Prototype pill. */
+    @media (max-width: 640px) {
+      .brand-suffix { display: none; }
+    }
     .header-link {
       font-size: 13px;
       color: var(--color-text-muted);
@@ -900,7 +905,7 @@
   <main>
     <div class="brand">
       <img src="assets/brand/logo-blue.png" alt="Passport to Wealth" width="36" height="36">
-      <span class="brand-text">PASSPORT TO WEALTH · CLARITY APP</span>
+      <span class="brand-text">PASSPORT TO WEALTH<span class="brand-suffix"> · CLARITY APP</span></span>
       <a href="docs/" class="header-link">Docs</a>
       <button id="header-pill" class="pill" data-open-prototype-modal aria-label="Learn more about this prototype">Prototype</button>
     </div>

--- a/installer/index.html
+++ b/installer/index.html
@@ -900,7 +900,7 @@
   <main>
     <div class="brand">
       <img src="assets/brand/logo-blue.png" alt="Passport to Wealth" width="36" height="36">
-      <span class="brand-text">PASSPORT TO WEALTH · FINANCE CLARITY</span>
+      <span class="brand-text">PASSPORT TO WEALTH · CLARITY APP</span>
       <a href="docs/" class="header-link">Docs</a>
       <button id="header-pill" class="pill" data-open-prototype-modal aria-label="Learn more about this prototype">Prototype</button>
     </div>
@@ -1120,7 +1120,7 @@
     <footer>
       <div class="footer-cols">
         <div class="footer-brand">
-          <strong>Passport to Wealth · Finance Clarity</strong>
+          <strong>Passport to Wealth · Clarity App</strong>
           <p><em>Your crossborder finances, <span style="color: var(--color-gold);">the easy way.</span></em> Let your AI assistant sort your files and build you the right dashboard. Multi-currency, multi-account, multi-country.</p>
         </div>
         <div class="footer-col">


### PR DESCRIPTION
Two small commits:

- Rename header + footer brand label from 'Finance Clarity' to 'Clarity App'.
- Drop the '· CLARITY APP' suffix on mobile (<640px) so the header isn't cramped with brand + Docs link + Prototype pill.

Internal product name (skill ID, repo, tests) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)