### PR TITLE
Landing: shorter book caption

### DIFF
--- a/installer/index.html
+++ b/installer/index.html
@@ -1062,7 +1062,6 @@
           </a>
           <p class="book-meta">
             <strong>The Expat Money Playbook</strong>
-            Unlocking Your Passport to Wealth · by Arielle Tucker, CFP® and EA · published by Wiley.
             <a href="https://www.amazon.com/Expat-Money-Playbook-Arielle-Tucker/dp/1394415958" target="_blank" rel="noopener">View on Amazon ↗</a>
           </p>
         </div>


### PR DESCRIPTION
Removes the subtitle/byline line under the book cover so the caption is just title + Amazon link.