### PR TITLE
Demo: serve sample data at /demo-data + add 'Try it' to /docs + demo-script walkthrough

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,6 +49,11 @@ jobs:
             --exclude '.DS_Store' \
             --exclude '.herenow' \
             installer/ _site/
+          # Mirror demo-kit/data → /demo-data so the sample files are
+          # downloadable from the same URL as the canonical here.now
+          # mirror (passporttowealth.app/demo-data/*).
+          mkdir -p _site/demo-data
+          rsync -a --exclude '.DS_Store' demo-kit/data/ _site/demo-data/
           # Substitute {{BUILD_STAMP}} in the landing index so the Pages
           # mirror has the same UTC stamp the canonical here.now publish
           # gets. Format matches install-telemetry build_stamp.

--- a/dev/demo-script.md
+++ b/dev/demo-script.md
@@ -57,6 +57,68 @@ If anything fails, the installer writes `install.log` and offers to bundle it fo
 
 ---
 
+## Demo dry-run on your own Mac (5 min, before showing a client)
+
+If you (the advisor) are practicing the demo on your own machine before running it live, use the synthetic sample data — it covers every code path without needing real client files.
+
+**Sample data location** (in the repo): `demo-kit/data/` — 7 files, fully synthetic, deterministic seed-42 generator, ~52KB total.
+
+| File | What it is | What it tests |
+|---|---|---|
+| `demo_checking_2025.csv` | 12 months USD checking, ~400 transactions | Sorted to `01_bank_transactions/`, normalized, categorized |
+| `demo_brokerage_2025.csv` | Small brokerage with paired transfers | Sign convention; transfer-pair detection |
+| `duplicate_q3_checking.csv` | Q3 of checking duplicated | Deduper should catch the 100% overlap |
+| `paystub_jan_2025.pdf` | Synthetic paystub (text layer) | OP-1: routes to `02_payslips/`, **does not open** |
+| `tax_assessment_2024.pdf` | Synthetic tax doc (text layer) | OP-1: routes to `04_reference_docs/`, skipped |
+| `amazon_orders_2025.pdf` | Synthetic Amazon order summary | Routes to `03_amazon_orders/`, OK to read |
+| `mystery_scan.pdf` | Image-only PDF (no text layer) | No-OCR rule routes to `05_other/` |
+
+### Running it
+
+Assumes you've already run `curl -fsSL https://passporttowealth.app/install | bash` and have `~/Documents/my-finances/` set up.
+
+```bash
+# 1. Copy the sample files into your inbox
+cp /path/to/passporttowealth/demo-kit/data/* ~/Documents/my-finances/inbox/
+
+# 2. (Optional) Confirm they landed
+ls ~/Documents/my-finances/inbox/
+
+# 3. Open Claude Code
+claude
+```
+
+Then in the assistant: *"build my report"*. Wall time on a warm machine: ~30 seconds.
+
+If you don't have the repo cloned, clients can also pull the same files directly from the website (mirrored at publish time):
+
+```bash
+cd ~/Documents/my-finances/inbox/ && curl -fsSL --remote-name-all \
+  "https://passporttowealth.app/demo-data/{demo_checking_2025.csv,demo_brokerage_2025.csv,duplicate_q3_checking.csv,paystub_jan_2025.pdf,tax_assessment_2024.pdf,amazon_orders_2025.pdf,mystery_scan.pdf}"
+```
+
+### Talking points to hit during the live demo
+
+- **"It found 47 files"** — the assistant counts files, says how many it sorted vs. skipped vs. wants to ask about. The skip-with-disclosure on paystubs/tax docs is the **privacy moment** (OP-1 in action).
+- **"Removed 3 duplicates"** — show the dedupe summary; `duplicate_q3_checking.csv` is intentional.
+- **"38 new merchants — want to review?"** — the assistant offers to walk through unfamiliar names so the user can teach the rules.
+- **The dashboard opens in your browser** — local file (`file://`), no third-party server. This is the **"you own this" moment**.
+- **Compare to the live demo dashboard** at `https://passporttowealth.app/dashboard-demo/` — same data, same render. Lets you and the client confirm the install is producing the right output.
+
+### Reset between practice runs
+
+Pipeline is deterministic; output identical every run.
+
+```bash
+rm -rf ~/Documents/my-finances/inbox/* \
+       ~/Documents/my-finances/0[1-5]_*/* \
+       ~/Documents/my-finances/pipeline/output/*
+```
+
+Then re-copy from `demo-kit/data/`.
+
+---
+
 ## Phase 1 — Open the workspace (2 min)
 
 Live, screen-sharing.

--- a/installer/build_docs.py
+++ b/installer/build_docs.py
@@ -583,6 +583,7 @@ def render_html(tools: list[str], python_packages: list[str], urls: list[str], p
     <h3>Docs</h3>
     <a href="#quick-start">Quick start</a>
     <a href="#what-you-get">What you get</a>
+    <a href="#try-it">Try it with sample data</a>
     <a href="#privacy-glance">Privacy at a glance</a>
     <a href="#what-installs">What this installs</a>
     <a href="#sharing">Sharing your dashboard</a>
@@ -649,6 +650,44 @@ def render_html(tools: list[str], python_packages: list[str], urls: list[str], p
 └── .env                         ← passcode + API key (chmod 600)</pre>
 
       <p>Re-entry is always <code>claude</code> from any terminal — the skill remembers where the workspace is. To refresh after dropping new files: open the assistant and say <em>"refresh."</em></p>
+    </section>
+
+    <section class="doc-section" id="try-it">
+      <h2>Try it with sample data</h2>
+      <p class="section-lede">Don't have your bank exports handy yet? You can run the full pipeline against a fully-synthetic 12-month fixture (deterministic seed-42 generator, fake names and amounts, no real money). It exercises every step the pipeline does on real data.</p>
+
+      <h3>1. Download the sample files into your inbox</h3>
+      <p>From any terminal:</p>
+      <pre class="code">cd ~/Documents/my-finances/inbox/ \\
+  &amp;&amp; curl -fsSL --remote-name-all \\
+    "https://passporttowealth.app/demo-data/{{demo_checking_2025.csv,demo_brokerage_2025.csv,duplicate_q3_checking.csv,paystub_jan_2025.pdf,tax_assessment_2024.pdf,amazon_orders_2025.pdf,mystery_scan.pdf}}"</pre>
+
+      <p>The seven files together are about 35KB. They cover every code path the pipeline supports:</p>
+      <ul>
+        <li><code>demo_checking_2025.csv</code> — 12 months of USD checking, ~400 transactions.</li>
+        <li><code>demo_brokerage_2025.csv</code> — small brokerage with paired transfers (tests the sign convention).</li>
+        <li><code>duplicate_q3_checking.csv</code> — Q3 of the checking file duplicated (the deduper should catch this).</li>
+        <li><code>paystub_jan_2025.pdf</code> — synthetic paystub with a text layer (privacy classifier should route it to <code>02_payslips/</code> and <strong>not</strong> open it).</li>
+        <li><code>tax_assessment_2024.pdf</code> — synthetic tax doc (same: routed but not opened).</li>
+        <li><code>amazon_orders_2025.pdf</code> — synthetic Amazon order summary (OK to read, lands in <code>03_amazon_orders/</code>).</li>
+        <li><code>mystery_scan.pdf</code> — image-only PDF with no text layer (no-OCR rule routes it to <code>05_other/</code>).</li>
+      </ul>
+
+      <h3>2. Open the assistant and ask it to build the report</h3>
+      <pre class="code">claude</pre>
+      <p>Then in the assistant, say:</p>
+      <pre class="code">build my report</pre>
+      <p>The assistant will sort the files into buckets, dedupe, normalize transactions, fetch FX rates, categorize against the starter rules, run the sanity check, and build the dashboard. Wall time on a warm machine: about 30 seconds.</p>
+
+      <h3>3. The dashboard opens in your browser</h3>
+      <p>Local file, no third-party server. You can compare it to the <a class="body-link" href="../dashboard-demo/" target="_blank" rel="noopener">live demo dashboard</a> — same data, same layout — to verify your install is producing the right output.</p>
+
+      <h3>Reset between runs</h3>
+      <p>The pipeline is deterministic, so you can re-run as many times as you want. To start fresh:</p>
+      <pre class="code">rm -rf ~/Documents/my-finances/inbox/* \\
+       ~/Documents/my-finances/0[1-5]_*/* \\
+       ~/Documents/my-finances/pipeline/output/*</pre>
+      <p>Then re-download the sample files into <code>inbox/</code> and run again.</p>
     </section>
 
     <section class="doc-section" id="privacy-glance">

--- a/installer/docs/index.html
+++ b/installer/docs/index.html
@@ -239,6 +239,7 @@
     <h3>Docs</h3>
     <a href="#quick-start">Quick start</a>
     <a href="#what-you-get">What you get</a>
+    <a href="#try-it">Try it with sample data</a>
     <a href="#privacy-glance">Privacy at a glance</a>
     <a href="#what-installs">What this installs</a>
     <a href="#sharing">Sharing your dashboard</a>
@@ -305,6 +306,44 @@
 └── .env                         ← passcode + API key (chmod 600)</pre>
 
       <p>Re-entry is always <code>claude</code> from any terminal — the skill remembers where the workspace is. To refresh after dropping new files: open the assistant and say <em>"refresh."</em></p>
+    </section>
+
+    <section class="doc-section" id="try-it">
+      <h2>Try it with sample data</h2>
+      <p class="section-lede">Don't have your bank exports handy yet? You can run the full pipeline against a fully-synthetic 12-month fixture (deterministic seed-42 generator, fake names and amounts, no real money). It exercises every step the pipeline does on real data.</p>
+
+      <h3>1. Download the sample files into your inbox</h3>
+      <p>From any terminal:</p>
+      <pre class="code">cd ~/Documents/my-finances/inbox/ \
+  &amp;&amp; curl -fsSL --remote-name-all \
+    "https://passporttowealth.app/demo-data/{demo_checking_2025.csv,demo_brokerage_2025.csv,duplicate_q3_checking.csv,paystub_jan_2025.pdf,tax_assessment_2024.pdf,amazon_orders_2025.pdf,mystery_scan.pdf}"</pre>
+
+      <p>The seven files together are about 35KB. They cover every code path the pipeline supports:</p>
+      <ul>
+        <li><code>demo_checking_2025.csv</code> — 12 months of USD checking, ~400 transactions.</li>
+        <li><code>demo_brokerage_2025.csv</code> — small brokerage with paired transfers (tests the sign convention).</li>
+        <li><code>duplicate_q3_checking.csv</code> — Q3 of the checking file duplicated (the deduper should catch this).</li>
+        <li><code>paystub_jan_2025.pdf</code> — synthetic paystub with a text layer (privacy classifier should route it to <code>02_payslips/</code> and <strong>not</strong> open it).</li>
+        <li><code>tax_assessment_2024.pdf</code> — synthetic tax doc (same: routed but not opened).</li>
+        <li><code>amazon_orders_2025.pdf</code> — synthetic Amazon order summary (OK to read, lands in <code>03_amazon_orders/</code>).</li>
+        <li><code>mystery_scan.pdf</code> — image-only PDF with no text layer (no-OCR rule routes it to <code>05_other/</code>).</li>
+      </ul>
+
+      <h3>2. Open the assistant and ask it to build the report</h3>
+      <pre class="code">claude</pre>
+      <p>Then in the assistant, say:</p>
+      <pre class="code">build my report</pre>
+      <p>The assistant will sort the files into buckets, dedupe, normalize transactions, fetch FX rates, categorize against the starter rules, run the sanity check, and build the dashboard. Wall time on a warm machine: about 30 seconds.</p>
+
+      <h3>3. The dashboard opens in your browser</h3>
+      <p>Local file, no third-party server. You can compare it to the <a class="body-link" href="../dashboard-demo/" target="_blank" rel="noopener">live demo dashboard</a> — same data, same layout — to verify your install is producing the right output.</p>
+
+      <h3>Reset between runs</h3>
+      <p>The pipeline is deterministic, so you can re-run as many times as you want. To start fresh:</p>
+      <pre class="code">rm -rf ~/Documents/my-finances/inbox/* \
+       ~/Documents/my-finances/0[1-5]_*/* \
+       ~/Documents/my-finances/pipeline/output/*</pre>
+      <p>Then re-download the sample files into <code>inbox/</code> and run again.</p>
     </section>
 
     <section class="doc-section" id="privacy-glance">

--- a/installer/publish-landing.sh
+++ b/installer/publish-landing.sh
@@ -43,6 +43,14 @@ python3 "$REPO_ROOT/installer/build_docs.py"
 rsync -aL --exclude '.herenow' --exclude '.DS_Store' \
   "$SCRIPT_DIR/" "$BUILD_DIR/"
 
+# Mirror demo-kit/data → /demo-data so testers can curl the sample
+# files directly from passporttowealth.app/demo-data/* and drop them
+# into their workspace inbox. Single source of truth stays at
+# demo-kit/data/; we don't commit a duplicate.
+echo "▸ Mirroring demo-kit/data → /demo-data"
+mkdir -p "$BUILD_DIR/demo-data"
+rsync -a --exclude '.DS_Store' "$REPO_ROOT/demo-kit/data/" "$BUILD_DIR/demo-data/"
+
 # Substitute {{BUILD_STAMP}} with current UTC stamp (yyyymmddHHMMSS, same
 # format as the install_started telemetry build_stamp so the two correlate).
 STAMP="$(date -u +%Y%m%d%H%M%S)"


### PR DESCRIPTION
Three things together for the upcoming pilot demo:

1. publish-landing.sh + pages.yml mirror demo-kit/data into the publish bundle as /demo-data. Single source of truth stays at demo-kit/data.
2. New /docs section 'Try it with sample data' with one-curl-command download, per-file table, run + reset instructions.
3. dev/demo-script.md gets a 'Demo dry-run on your own Mac' section near the top with sample-data location, run commands, and talking points.

Live: passporttowealth.app/demo-data/{7 files} all 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)