### PR TITLE
Installer: don't exec claude under curl-pipe-bash (terminal-freeze fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Each of these hit production undetected. Tests now guard them. If a test fails w
 - `pages.yml` placeholder guard — don't disable it. `{{BUILD_STAMP}}` in `installer/index.html` is intentional; substitution happens at publish time via `installer/publish-landing.sh` or the workflow.
 - `test_installer_curl_pipe_safe` — install.sh must `exec </dev/tty` early, capture `INTERACTIVE=1` once, and never re-test `[ -t 0 ]` later. Bash 3.2 (Apple's default) returns stale results from `[ -t 0 ]` after redirect.
 - `test_installer_consent_gate_does_not_silently_cancel_on_empty` — empty input at the consent gate must re-prompt, not silently cancel. Was a real bug.
+- `test_install_sh_start_now_only_execs_when_real_tty` — the end-of-install "Want to start now? [Y/n]" prompt must only `exec claude` when `INTERACTIVE_DIAG="already_tty"`. Under curl-pipe-bash (`rebind_ok`), bash isn't the terminal's foreground process group, so exec-ing into a TUI freezes the terminal — claude runs but keystrokes don't reach it. Fall back to printing instructions; user types `claude` themselves in the same window.
 
 ---
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -822,12 +822,44 @@ printf '\n%s▶ Want to start now? [Y/n]%s ' "$BOLD" "$RESET"
 read -r START_ANSWER
 case "$(printf '%s' "$START_ANSWER" | tr '[:upper:]' '[:lower:]' | xargs)" in
   ""|y|yes)
-    log "starting claude with primer prompt"
-    export FCB_WORKSPACE="$WS"
-    cd "$WS" || true
-    exec 3>&-                # release the install-log fd before exec
-    exec claude --add-dir "$WS" "Welcome. Drop your financial files into $WS/inbox/ and say 'build my report' when you're ready."
-    # exec replaces this process — nothing below runs.
+    # ──────────────────────────────────────────────────────────────────────
+    # Two paths from here, depending on how install.sh was invoked.
+    #
+    # (a) INTERACTIVE_DIAG="already_tty" — user ran the script directly
+    #     from a real terminal (e.g. `bash install.sh`). Bash owns the
+    #     terminal's foreground process group; exec-ing into claude
+    #     transfers that role cleanly. Do the exec.
+    #
+    # (b) INTERACTIVE_DIAG="rebind_ok" — user ran `curl … | bash`. We
+    #     successfully rebound stdin to /dev/tty so reads work, but the
+    #     bash process is NOT the terminal's foreground process group
+    #     (it's part of the curl pipeline). Exec-ing claude here makes
+    #     claude inherit /dev/tty as stdin but it can't take foreground,
+    #     so keystrokes go nowhere — the terminal looks frozen.
+    #     Print friendly instructions instead; user types `claude`
+    #     themselves in the same window, which spawns a fresh process
+    #     with proper foreground role.
+    # ──────────────────────────────────────────────────────────────────────
+    if [ "${INTERACTIVE_DIAG:-}" = "already_tty" ]; then
+      log "starting claude with primer prompt (already_tty path — exec safe)"
+      export FCB_WORKSPACE="$WS"
+      cd "$WS" || true
+      exec 3>&-                # release the install-log fd before exec
+      exec claude --add-dir "$WS" "Welcome. Drop your financial files into $WS/inbox/ and say 'build my report' when you're ready."
+      # exec replaces this process — nothing below runs.
+    fi
+    # curl-pipe-bash path: don't exec; tell the user how to start in one step.
+    log "start-now requested but tty_state=${INTERACTIVE_DIAG} — printing instructions instead of exec"
+    say
+    say "${BOLD}You're all set.${RESET} Type one word in this same terminal to start:"
+    say
+    say "    ${BOLD}claude${RESET}"
+    say
+    say "Then tell it ${BOLD}\"build my report\"${RESET} once you've dropped your files in:"
+    say "    ${BOLD}$WS/inbox/${RESET}"
+    say
+    say "${DIM}(We can't auto-launch from a curl-piped install — Terminal needs you to type it directly so it can take over the keyboard properly.)${RESET}"
+    say
     ;;
   *)
     say

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -613,6 +613,32 @@ class TestPipelineHealth(unittest.TestCase):
         self.assertIn("export ANTHROPIC_API_KEY=", cmd,
             "must export ANTHROPIC_API_KEY into the shell rc")
 
+    def test_install_sh_start_now_only_execs_when_real_tty(self):
+        """Bug found 2026-05-07 in tester dry-run: the end-of-install
+        'Want to start now? [Y/n]' prompt was unconditionally `exec`-ing
+        into claude. That works when the user ran the script directly
+        from a real terminal, but fails under curl-pipe-bash: bash isn't
+        the terminal's foreground process group, so the exec'd claude
+        inherits stdin pointing at /dev/tty but can't take foreground.
+        Result: keystrokes don't reach claude, terminal looks frozen.
+
+        Fix: only exec when `INTERACTIVE_DIAG="already_tty"`. In the
+        rebind_ok (curl-pipe-bash) case, print instructions and let the
+        user type `claude` themselves — that gives the new process
+        proper foreground role."""
+        cmd = (REPO / "installer" / "install.sh").read_text(encoding="utf-8")
+        # The exec is gated on the TTY diagnostic
+        self.assertIn('if [ "${INTERACTIVE_DIAG:-}" = "already_tty" ]; then', cmd,
+            "exec claude must be gated on INTERACTIVE_DIAG=already_tty (real terminal)")
+        # The exec lives inside that gate, not before it
+        gate_idx = cmd.find('if [ "${INTERACTIVE_DIAG:-}" = "already_tty" ]; then')
+        exec_idx = cmd.find('exec claude --add-dir "$WS"')
+        self.assertGreater(exec_idx, gate_idx,
+            "exec claude must come AFTER the already_tty gate")
+        # And the curl-pipe-bash fallback gives the user the one word to type
+        self.assertIn("Type one word in this same terminal to start", cmd,
+            "curl-pipe-bash fallback must tell the user to type 'claude'")
+
     def test_refresh_sh_defaults_to_workspace_venv(self):
         """B9.10 — without START-HERE activating the venv, refresh.sh has to
         default PYTHON to the workspace venv's python so the pipeline runs


### PR DESCRIPTION
Tester-found regression. The end-of-install 'Want to start now?' Yes branch was unconditionally exec-ing claude. That works when the user ran the script directly from a real terminal, but freezes the terminal under curl-pipe-bash — claude inherits stdin pointing at /dev/tty but bash doesn't own the foreground process group, so claude can't take it over either.

Fix: gate the exec on INTERACTIVE_DIAG='already_tty'. In the curl-pipe-bash case (rebind_ok), print friendly instructions and let the user type 'claude' themselves in the same window — which spawns a fresh process under the user's actual shell with proper foreground role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)