### PR TITLE
Installer: disk-space floor 5 GB → 2 GB

### DIFF
--- a/dev/demo-script.md
+++ b/dev/demo-script.md
@@ -25,7 +25,7 @@ A first-time, non-technical client with a folder of their own financial files (b
 
 Same checklist every client. If any of these aren't true, fix them before sending the install link:
 
-1. **Mac running macOS 13 (Ventura) or later**, personal (not employer-managed), at least 10 GB free.
+1. **Mac running macOS 13 (Ventura) or later**, personal (not employer-managed), at least 2 GB free (the installer enforces this; realistic peak install footprint is ~300–400 MB across uv, Python 3.11, Node, Claude Code, and the skills).
 2. **One of:** active Claude Pro subscription, active Claude Max subscription, or Anthropic API key with billing set up. The installer will guide them through whichever they have.
 3. **Heads-up sent** that the install takes ~10 minutes if they've installed developer tools before, up to an hour on a fresh Mac.
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -313,8 +313,8 @@ Write-OkPaced "Windows version OK (build $buildNum)"
 # Free disk space on home drive
 $drive = (Get-Item $env:USERPROFILE).PSDrive
 $freeGB = [math]::Round($drive.Free / 1GB)
-if ($freeGB -lt 5) {
-    Write-FailLine "Only $freeGB GB free on your home drive. I need at least 5 GB."
+if ($freeGB -lt 2) {
+    Write-FailLine "Only $freeGB GB free on your home drive. I need at least 2 GB."
     Write-FailLine "Free up some space and run me again."
     Write-Log "FCB-0002 free_gb=$freeGB"
     exit 1

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -336,8 +336,8 @@ ok_paced "macOS version OK ($(sw_vers -productVersion))"
 # Disk space
 free_kb=$(df -k "$HOME" | awk 'NR==2 {print $4}')
 free_gb=$(( free_kb / 1024 / 1024 ))
-if [[ "$free_gb" -lt 5 ]]; then
-  fail "Only ${free_gb} GB free on your home drive. I need at least 5 GB."
+if [[ "$free_gb" -lt 2 ]]; then
+  fail "Only ${free_gb} GB free on your home drive. I need at least 2 GB."
   fail "Free up some space and run me again."
   log "FCB-0002 free_gb=$free_gb"
   exit 1


### PR DESCRIPTION
Realistic install footprint is ~300-400 MB peak. 5 GB was conservative slack; 2 GB still gives ~5x the working set. Lowers the gate so testers with fuller drives aren't blocked. demo-script.md updated from stale 10 GB to match.