### PR TITLE
Project settings: allowlist 7 read-only patterns

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Preview__preview_screenshot",
+      "mcp__Claude_Preview__preview_inspect",
+      "mcp__Claude_Preview__preview_console_logs",
+      "mcp__yakrover__auction_get_bids",
+      "mcp__yakrover__auction_get_wallet_balance",
+      "Bash(npm view *)",
+      "Bash(dig *)"
+    ]
+  }
+}


### PR DESCRIPTION
From fewer-permission-prompts transcript analysis. Reduces routine prompts on screenshot/inspect/console-logs/get_bids/get_wallet_balance MCPs + npm view + dig Bash commands. No mutating or code-execution patterns added.