### PR TITLE
build_site: net category totals so refunds offset spend, not inflate it

### DIFF
--- a/skill/scripts/build_site.py
+++ b/skill/scripts/build_site.py
@@ -116,8 +116,16 @@ def aggregate(rows: list[dict]) -> dict:
         else:
             by_month_out[month] += -r["amount"]
         if r["category"] != "Income":
-            by_category[r["category"]] += abs(r["amount"])
-            by_month_cat[month][r["category"]] += abs(r["amount"])
+            # Net spend: outflows (negative amount) add positive spend;
+            # refunds/inflows (positive amount) subtract. Avoids inflating
+            # category totals when a credit hits the same category as past
+            # debits — e.g. a Krankenkasse benefit payout hitting the same
+            # merchant rule as health-insurance contributions, an Amazon
+            # return hitting the same rule as the original purchase, a
+            # Wise FX-fee refund, a deposit return, a chargeback.
+            net_spend = -r["amount"]
+            by_category[r["category"]] += net_spend
+            by_month_cat[month][r["category"]] += net_spend
         rows_for_table.append(r)
 
     months = sorted(by_month_in.keys() | by_month_out.keys())
@@ -209,7 +217,7 @@ def _generate_insights(table_rows, by_category, by_month_in, by_month_out, month
     # 3. Recurring subscriptions
     subs_rows = [r for r in table_rows if r["category"] == "Subscriptions"]
     if subs_rows:
-        subs_total = sum(abs(r["amount"]) for r in subs_rows)
+        subs_total = sum(-r["amount"] for r in subs_rows)
         n_subs = len(subs_rows)
         per_month = subs_total / max(len(months), 1)
         insights.append(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -369,6 +369,64 @@ class TestBuildSite(PipelineTestBase):
         self.assertGreaterEqual(len(nav_anchors), 6, f"expected ≥6 nav items; got {nav_anchors}")
 
 
+class TestNetCategoryAggregation(unittest.TestCase):
+    """A positive-amount row in a non-Income category must REDUCE that
+    category's total, not inflate it. Regression guard for the abs() bug
+    in build_site.aggregate(): a refund / benefit payout / chargeback /
+    rental-deposit return that shares a merchant rule with prior debits
+    used to be added to the category instead of netted out, lying about
+    spend. Touches the Spend-by-category and Monthly-spend charts."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="fcb-net-cat-"))
+        self.workspace = self.tmpdir / "workspace"
+        self.workspace.mkdir()
+        out = self.workspace / "pipeline" / "output"
+        out.mkdir(parents=True)
+        # Insurance: $50 paid in Jan, $300 refund in Jan, $50 paid in Feb
+        # → expected net = -$200 (refund exceeds spend)
+        # Restaurants: one $10 debit → expected $10
+        with (out / "transactions_tagged.csv").open("w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["date", "description", "amount", "currency", "account",
+                        "source_file", "source_row", "category", "subcategory"])
+            w.writerow(["2026-01-15", "Insurance contribution", "-50.00", "USD",
+                        "Checking", "test.csv", "1", "Insurance", ""])
+            w.writerow(["2026-01-22", "Insurance refund / benefit",  "300.00", "USD",
+                        "Checking", "test.csv", "2", "Insurance", ""])
+            w.writerow(["2026-02-15", "Insurance contribution", "-50.00", "USD",
+                        "Checking", "test.csv", "3", "Insurance", ""])
+            w.writerow(["2026-02-20", "Coffee shop", "-10.00", "USD",
+                        "Checking", "test.csv", "4", "Restaurants", ""])
+        (out / "monthly_actuals.csv").write_text("month\n2026-01\n2026-02\n")
+        sanity = {
+            "confirmed_at": datetime.now(timezone.utc).isoformat(),
+            "acknowledged_violations": [],
+        }
+        (out / "sanity_confirmed.json").write_text(json.dumps(sanity))
+        self.env = {"FCB_WORKSPACE": str(self.workspace)}
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_refund_in_non_income_category_nets_against_spend(self):
+        run_script("build_site.py", env_extra=self.env)
+        html = (self.workspace / "site" / "index.html").read_text()
+        m = re.search(r'<script id="dashboard-data"[^>]*>(.+?)</script>', html, re.DOTALL)
+        self.assertIsNotNone(m, "dashboard-data <script> block missing")
+        d = json.loads(m.group(1))
+        cat_totals = dict(d["category_totals"])
+        # If abs() bug regressed: Insurance = 50+300+50 = 400.
+        # Correct net: -50+300-50 inverted to spend convention = -200.
+        self.assertAlmostEqual(
+            cat_totals.get("Insurance", 0), -200.00, places=2,
+            msg=(f"Insurance net should be -$200 (refunds exceed spend), "
+                 f"got {cat_totals.get('Insurance')}. abs() bug regression?"))
+        self.assertAlmostEqual(
+            cat_totals.get("Restaurants", 0), 10.00, places=2,
+            msg="Restaurants should be $10 net (single debit row)")
+
+
 class TestPipelineHealth(unittest.TestCase):
     """Smoke-level sanity that the pipeline scripts themselves are importable
     and the shared lib doesn't have basic syntax errors."""


### PR DESCRIPTION
## Summary

`aggregate()` in `build_site.py` summed every row into its category bucket using `abs()`, lumping positive credits (refunds, benefit payouts, chargebacks, deposit returns) with negative debits. The cashflow chart at the top of the dashboard was already sign-aware (line 114-117), so the two views disagreed: cashflow correctly counted a credit as income, but the spend-by-category chart added it to spend in the same row's category.

A real-data example that surfaced this: a Krankenkasse `Leistung` benefit payout (positive amount) matched the existing `(?i)krankenkasse|tk berlin|aok|barmer|dak` merchant rule. Instead of netting against the small monthly contribution, it added to it — the dashboard reported \$907 of Insurance spend in December for a user whose actual outflow was \$36.

Same class of bug affects:
- Online returns (Amazon, Zalando) sharing rules with the original purchase
- Wise / Revolut FX-fee refunds
- Rental security-deposit returns
- Double-charge reversals
- Subscription prorated refunds after cancellation

## Fix

Use net spend: outflows (negative amount) add positive spend; refunds/inflows (positive amount) subtract. Same change in the Subscriptions insight at line 220 where `subs_total = sum(abs(...))` had the same issue.

## Edge case

A category whose refunds exceed its spend in a period now has a negative total. `sorted(by_category.items(), key=lambda x: -x[1])` puts it at the bottom of the spend-by-category chart. The monthly stacked chart will render that month's segment below the axis — semantically correct (user got more back than they spent in that category) and rare in practice. If reviewers prefer to clamp to zero in the display layer only (keeping the raw payload net), that's a small follow-up; this PR ships the raw fix.

## Test plan

- [x] New `TestNetCategoryAggregation` injects a synthetic Insurance debit + larger Insurance refund + plain Restaurants debit. Verifies the dashboard's `category_totals` show Insurance net at -\$200 (refund exceeds spend) and Restaurants at +\$10 — not the abs sums of \$400 and \$10.
- [x] Full suite `python3 tests/test_pipeline.py` passes (41/41 — 40 prior + 1 new).