### PR TITLE
Promote next → main: pages.yml demo-kit regen fix

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,17 @@ jobs:
         # documented in installer/build_docs.py's curated map.
         run: python3 installer/build_docs.py
 
+      - name: Regenerate demo-kit fixture
+        # demo-kit/data/* is gitignored (*.csv / *.pdf rules) so a fresh
+        # checkout doesn't have it. The "Stage Pages content" step below
+        # rsyncs that directory into _site/demo-data, so we regenerate it
+        # here from the deterministic build_demo.py before staging.
+        # Mirrors the equivalent step in publish-landing.yml so the two
+        # publish paths stay in sync.
+        run: |
+          pip install --quiet reportlab~=4.4
+          python3 demo-kit/build_demo.py
+
       - name: Stage Pages content
         run: |
           mkdir -p _site


### PR DESCRIPTION
## Summary
Ports the demo-kit regen step from \`publish-landing.yml\` to \`pages.yml\`. The Pages backup mirror has been failing on every main push since 2026-05-07 because it rsyncs \`demo-kit/data/\` (gitignored) without first regenerating the fixtures.

## Why now
Came up while verifying the post-merge state of #35. Pre-existing, not caused by that PR, but worth clearing while context is fresh.

## Related
Branch protection's required-status-check contexts were also out of sync with the actual check display names (e.g. \`pipeline-regression\` listed instead of \`Pipeline regression suite\`). Updated separately via \`gh api PUT /branches/main/protection\` — no commit needed since branch protection lives outside the repo.

## Test plan
- [ ] CI green under the corrected required-check names (this PR is the first to test the new context list)
- [ ] Post-merge: \`pages.yml\` succeeds for the first time since 2026-05-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)