### PR TITLE
WS2 deck: shrink spaceship diagram on slide 22

### DIFF
--- a/installer/workingsession20260529/index.html
+++ b/installer/workingsession20260529/index.html
@@ -168,6 +168,7 @@ body::before {
 /* Slide 22 — top-anchored to keep title clear of wordmark */
 section.slide-spaceship { justify-content: flex-start !important; padding-top: 80px !important; }
 section.slide-spaceship h2 { margin-top: 0.1em; }
+section.slide-spaceship .diagram-img { max-height: 50vh; max-width: 78%; }
 
 .reveal .slide-number { font-family: var(--font-mono); background: transparent; color: var(--color-text-faint); font-size: 0.6em; right: 24px; bottom: 16px; letter-spacing: 0.04em; }
 .reveal .progress { height: 2px; color: var(--color-gold); }


### PR DESCRIPTION
## Summary
- Constrain slide-22 diagram to 50vh / 78% width
- More breathing room around the title and caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)